### PR TITLE
Update GptTrixEditor.php

### DIFF
--- a/src/Components/GptTrixEditor.php
+++ b/src/Components/GptTrixEditor.php
@@ -182,5 +182,45 @@ class GptTrixEditor extends RichEditor
             ->body($body)
             ->send();
     }
+    
+    protected array|Arrayable|string|Closure|null $option = [];
+
+    public function option(array|Arrayable|string|Closure|null $option): static
+    {
+        $this->option = $option;
+
+        return $this;
+    }
+
+    public function getOption(): array
+    {
+        $option = $this->evaluate($this->option) ?? [];
+        $options = [];
+
+        // Check if $option is a string and if a function called "enum_exists" exists,
+        // and if the enum specified by $option exists
+
+        if (is_string($option) && function_exists('enum_exists') && enum_exists($option)) {
+            // Convert the enum cases into key-value pairs
+            $option = collect($option::cases())->mapWithKeys(static fn($case) => [($case?->value ?? $case->name) => $case->name]);
+        }
+
+        // Convert $option to an array if it implements the Arrayable interface
+        if ($option instanceof Arrayable) {
+            $options = $option->toArray();
+        }
+        // If $option is already an array, assign it to $options directly
+        elseif (is_array($option)) {
+            $options = $option;
+        }
+
+        return $options;
+    }
+
+
+    public function hasDynamicOptions(): bool
+    {
+        return $this->option instanceof Closure;
+    }
 
 }


### PR DESCRIPTION
Title: Enhance Option Handling in GptTrixEditor

Description:

This pull request improves the way the GptTrixEditor handles options by making it more flexible and robust.

1. Extended Data Types for $option: The $option property can now handle multiple data types including an array, an instance of an Arrayable, a string, a Closure, or null.

2. option Method: A setter method for $option has been added. This method allows for method chaining.

3. getOption Method: This method retrieves the $option in array format. If $option is a valid enum string, it maps the enum cases into an array of key-value pairs. If $option implements the Arrayable interface, it gets converted into an array. If $option is already an array, it is directly assigned to $options.

4. hasDynamicOptions Method: This method checks if the $option property is a closure, indicating that the options are dynamic.